### PR TITLE
Update ghostwriter/json to version 3.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ghostwriter/container": "^6.1.1",
         "ghostwriter/event-dispatcher": "^6.1.0",
         "ghostwriter/filesystem": "^0.2.0",
-        "ghostwriter/json": "^3.0.1",
+        "ghostwriter/json": "^3.0.2",
         "ghostwriter/option": "^2.0.0",
         "ghostwriter/result": "^2.0.0",
         "ghostwriter/shell": "^0.1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "457b0c92162dbe2e33dd74ae444864df",
+    "content-hash": "abfb03475ef1603f16837329376f1c30",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -526,16 +526,16 @@
         },
         {
             "name": "ghostwriter/json",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/json.git",
-                "reference": "a672903f17a2f5e3a0359436ef7a10b3cf33462b"
+                "reference": "133d8c816818938e7dd2a6f14b5e804efa43250c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/json/zipball/a672903f17a2f5e3a0359436ef7a10b3cf33462b",
-                "reference": "a672903f17a2f5e3a0359436ef7a10b3cf33462b",
+                "url": "https://api.github.com/repos/ghostwriter/json/zipball/133d8c816818938e7dd2a6f14b5e804efa43250c",
+                "reference": "133d8c816818938e7dd2a6f14b5e804efa43250c",
                 "shasum": ""
             },
             "require": {
@@ -545,16 +545,22 @@
             "require-dev": {
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/container": "^6.0.1",
+                "ghostwriter/container": "^6.1.1",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.4",
-                "symfony/var-dumper": "^7.3.5"
+                "phpunit/phpunit": "^13.1.3",
+                "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/ghostwriter/json",
+                    "name": "ghostwriter/json"
+                },
                 "ghostwriter": {
                     "container": {
-                        "definition": "Ghostwriter\\Json\\Container\\JsonDefinition"
+                        "provider": [
+                            "Ghostwriter\\Json\\Container\\JsonProvider"
+                        ]
                     }
                 }
             },
@@ -565,7 +571,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-4-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -593,7 +599,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-25T16:30:02+00:00"
+            "time": "2026-04-14T15:18:31+00:00"
         },
         {
             "name": "ghostwriter/option",


### PR DESCRIPTION
Updates the `ghostwriter/json` dependency from `3.0.1` to `3.0.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`